### PR TITLE
Restore allocation history that was removed by a bug in the backend

### DIFF
--- a/applications/f1tcdiusiow3wwraen7rnmiog2akmgkccnqqxftta.json
+++ b/applications/f1tcdiusiow3wwraen7rnmiog2akmgkccnqqxftta.json
@@ -47,6 +47,22 @@
   },
   "Allocation Requests": [
     {
+      "ID": "349b75af-f622-4e63-9d80-fdbc527619bc",
+      "Request Type": "First",
+      "Created At": "2024-08-08 14:47:35.994455933 UTC",
+      "Updated At": "2024-08-08 14:47:35.994457638 UTC",
+      "Active": false,
+      "Allocation Amount": "50TiB",
+      "Signers": [
+        {
+          "Github Username": "kevzak",
+          "Signing Address": "f1v24knjbqv5p6qrmfjj5xmlaoddzqnon2oxkzkyq",
+          "Created At": "2024-08-08 14:49:14.676000000 UTC",
+          "Message CID": "bafy2bzacedc5slc73vnr3hybqnavakxma6koj2a27ant2sgq3ci3cwsordaa4"
+        }
+      ]
+    },
+    {
       "ID": "198b2111-d04f-4501-b192-6250cab04bce",
       "Request Type": "First",
       "Created At": "2024-10-01 09:59:38.685243180 UTC",


### PR DESCRIPTION
Here's a commit where it was erroneously removed: https://github.com/fidlabs/Open-Data-Pathway/pull/81/commits/90a509e4b301ff5521259a15b9359e9014f4882f

Here's a proof that it did happen onchain: https://beryx.io/fil/mainnet/txs/bafy2bzacedc5slc73vnr3hybqnavakxma6koj2a27ant2sgq3ci3cwsordaa4?tab=internalMessages